### PR TITLE
Fix system command quoting in codegens

### DIFF
--- a/libs/base/System.idr
+++ b/libs/base/System.idr
@@ -104,7 +104,10 @@ prim__system : String -> PrimIO Int
 
 export
 system : HasIO io => String -> io Int
-system cmd = primIO (prim__system (if isWindows then "\"" ++ cmd ++ "\"" else cmd))
+system cmd = primIO $ prim__system $
+  if isWindows && isPrefixOf "\"" cmd
+    then "\"" ++ cmd ++ "\""
+    else cmd
 
 %foreign support "idris2_time"
          "scheme:blodwen-time"

--- a/src/Compiler/ES/Node.idr
+++ b/src/Compiler/ES/Node.idr
@@ -18,11 +18,9 @@ import System.File
 import Data.Maybe
 
 findNode : IO String
-findNode = do
-   Nothing <- idrisGetEnv "NODE"
-      | Just node => pure node
-   path <- pathLookup ["node"]
-   pure $ fromMaybe "/usr/bin/env node" path
+findNode =
+  do env <- idrisGetEnv "NODE"
+     pure $ fromMaybe "node" env
 
 ||| Compile a TT expression to Node
 compileToNode : Ref Ctxt Defs -> ClosedTerm -> Core String

--- a/src/Compiler/Scheme/Chez.idr
+++ b/src/Compiler/Scheme/Chez.idr
@@ -36,7 +36,7 @@ findChez
     = do Nothing <- idrisGetEnv "CHEZ"
             | Just chez => pure chez
          path <- pathLookup ["chez", "chezscheme9.5", "scheme"]
-         pure $ fromMaybe "/usr/bin/env scheme" path
+         pure $ fromMaybe "scheme" path
 
 -- Given the chez compiler directives, return a list of pairs of:
 --   - the library file name
@@ -372,7 +372,7 @@ startChezCmd chez appdir target = unlines
     [ "@echo off"
     , "set APPDIR=%~dp0"
     , "set PATH=%APPDIR%\\" ++ appdir ++ ";%PATH%"
-    , "\"" ++ chez ++ "\" --script \"%APPDIR%/" ++ target ++ "\" %*"
+    , "\"" ++ chez ++ "\" --script \"%APPDIR%\\" ++ target ++ "\" %*"
     ]
 
 startChezWinSh : String -> String -> String -> String
@@ -382,9 +382,8 @@ startChezWinSh chez appdir target = unlines
     , "set -e # exit on any error"
     , ""
     , "DIR=$(dirname \"$(readlink -f -- \"$0\")\")"
-    , "CHEZ=$(cygpath \"" ++ chez ++"\")"
     , "export PATH=\"$DIR/" ++ appdir ++ "\":$PATH"
-    , "\"$CHEZ\" --script \"$DIR/" ++ target ++ "\" \"$@\""
+    , "\"" ++ chez ++ "\" --script \"$DIR/" ++ target ++ "\" \"$@\""
     ]
 
 ||| Compile a TT expression to Chez Scheme

--- a/src/Compiler/Scheme/Gambit.idr
+++ b/src/Compiler/Scheme/Gambit.idr
@@ -32,13 +32,13 @@ import System.Info
 findGSI : IO String
 findGSI =
   do env <- idrisGetEnv "GAMBIT_GSI"
-     pure $ fromMaybe "/usr/bin/env gsi" env
+     pure $ fromMaybe "gsi" env
 
 -- TODO Look for gsc-script, then gsc
 findGSC : IO String
 findGSC =
   do env <- idrisGetEnv "GAMBIT_GSC"
-     pure $ fromMaybe "/usr/bin/env gsc" env
+     pure $ fromMaybe "gsc" env
 
 findGSCBackend : IO String
 findGSCBackend =


### PR DESCRIPTION
The /usr/bin/env indirection will only break things, e.g. `#!/usr/bin/env scheme --script` doesn't work.