### PR TITLE
Windows / filepath quoting fixes

### DIFF
--- a/bootstrap-stage1-chez.sh
+++ b/bootstrap-stage1-chez.sh
@@ -14,8 +14,8 @@ echo "Bootstrapping SCHEME=$SCHEME IDRIS2_VERSION=$IDRIS2_VERSION"
 # Compile the bootstrap scheme
 # TODO: Move boot-build to Makefile in bootstrap/Makefile
 cd bootstrap
-echo "Building idris2-boot from idris2-boot.ss"
-${SCHEME} --script compile.ss
+echo "Building idris2-boot.so from idris2-boot.ss"
+"${SCHEME}" --script compile.ss
 
 # Put the result in the usual place where the target goes
 mkdir -p ../build/exec

--- a/bootstrap-stage1-racket.sh
+++ b/bootstrap-stage1-racket.sh
@@ -11,7 +11,7 @@ echo "Bootstrapping IDRIS2_VERSION=$IDRIS2_VERSION"
 # Compile the bootstrap scheme
 cd bootstrap
 echo "Building idris2-boot from idris2-boot.rkt"
-raco exe idris2_app/idris2-boot.rkt
+"${RACKET_RACO:-raco}" exe idris2_app/idris2-boot.rkt
 
 # Put the result in the usual place where the target goes
 mkdir -p ../build/exec

--- a/bootstrap/idris2-boot.sh
+++ b/bootstrap/idris2-boot.sh
@@ -7,14 +7,15 @@ if [ -z "$SCHEME" ]; then
     exit 1
 fi
 
-if [ "$(uname)" = Darwin ]; then
+if [ "$OS" = windows ] || [ "$OS" = Windows_NT ]; then
+    DIR=$(dirname "$(readlink -f -- "$0" || cygpath -a -- "$0")")
+    PATH=$DIR/idris2_app:$PATH
+elif [ "$(uname)" = Darwin ]; then
     DIR=$(zsh -c 'printf %s "$0:A:h"' "$0")
 else
     DIR=$(dirname "$(readlink -f -- "$0")")
 fi
 
-LD_LIBRARY_PATH="$DIR/idris2_app":$LD_LIBRARY_PATH
-PATH="$DIR/idris2_app":$PATH
-export LD_LIBRARY_PATH PATH
+export LD_LIBRARY_PATH="$DIR/idris2_app:$LD_LIBRARY_PATH"
 
-${SCHEME} --script "$DIR/idris2_app/idris2-boot.so" "$@"
+"${SCHEME}" --script "$DIR/idris2_app/idris2-boot.so" "$@"

--- a/bootstrap/idris2-rktboot.sh
+++ b/bootstrap/idris2-rktboot.sh
@@ -2,14 +2,15 @@
 
 set -e # exit on any error
 
-if [ "$(uname)" = Darwin ]; then
+if [ "$OS" = windows ] || [ "$OS" = Windows_NT ]; then
+    DIR=$(dirname "$(readlink -f -- "$0" || cygpath -a -- "$0")")
+    PATH=$DIR/idris2_app:$PATH
+elif [ "$(uname)" = Darwin ]; then
     DIR=$(zsh -c 'printf %s "$0:A:h"' "$0")
 else
     DIR=$(dirname "$(readlink -f -- "$0")")
 fi
 
-LD_LIBRARY_PATH="$DIR/idris2_app":$LD_LIBRARY_PATH
-PATH="$DIR/idris2_app":$PATH
-export LD_LIBRARY_PATH PATH
+export LD_LIBRARY_PATH="$DIR/idris2_app:$LD_LIBRARY_PATH"
 
 "$DIR/idris2_app/idris2-boot" "$@"

--- a/src/Compiler/Scheme/Chez.idr
+++ b/src/Compiler/Scheme/Chez.idr
@@ -363,7 +363,7 @@ startChezPreamble = unlines
 
 startChez : String -> String -> String
 startChez appdir target = startChezPreamble ++ unlines
-    [ "export LD_LIBRARY_PATH=\"$DIR/" ++ appdir ++ "\":$LD_LIBRARY_PATH"
+    [ "export LD_LIBRARY_PATH=\"$DIR/" ++ appdir ++ ":$LD_LIBRARY_PATH\""
     , "\"$DIR/" ++ target ++ "\" \"$@\""
     ]
 
@@ -371,8 +371,8 @@ startChezCmd : String -> String -> String -> String
 startChezCmd chez appdir target = unlines
     [ "@echo off"
     , "set APPDIR=%~dp0"
-    , "set PATH=%APPDIR%\\" ++ appdir ++ ";%PATH%"
-    , "\"" ++ chez ++ "\" --script \"%APPDIR%\\" ++ target ++ "\" %*"
+    , "set PATH=%APPDIR%" ++ appdir ++ ";%PATH%"
+    , "\"" ++ chez ++ "\" --script \"%APPDIR%" ++ target ++ "\" %*"
     ]
 
 startChezWinSh : String -> String -> String -> String
@@ -381,8 +381,8 @@ startChezWinSh chez appdir target = unlines
     , ""
     , "set -e # exit on any error"
     , ""
-    , "DIR=$(dirname \"$(readlink -f -- \"$0\")\")"
-    , "export PATH=\"$DIR/" ++ appdir ++ "\":$PATH"
+    , "DIR=$(dirname \"$(readlink -f -- \"$0\" || cygpath -a -- \"$0\")\")"
+    , "PATH=\"$DIR/" ++ appdir ++ ":$PATH\""
     , "\"" ++ chez ++ "\" --script \"$DIR/" ++ target ++ "\" \"$@\""
     ]
 

--- a/src/Compiler/Scheme/ChezSep.idr
+++ b/src/Compiler/Scheme/ChezSep.idr
@@ -54,7 +54,7 @@ schFooter = "(collect 4)\n(blodwen-run-finalisers)\n"
 
 startChez : String -> String -> String -> String
 startChez chez appDirSh targetSh = Chez.startChezPreamble ++ unlines
-    [ "export LD_LIBRARY_PATH=\"$DIR/" ++ appDirSh ++ "\":$LD_LIBRARY_PATH"
+    [ "export LD_LIBRARY_PATH=\"$DIR/" ++ appDirSh ++ ":$LD_LIBRARY_PATH\""
     , "\"" ++ chez ++ "\" -q "
         ++ "--libdirs \"$DIR/" ++ appDirSh ++ "\" "
         ++ "--program \"$DIR/" ++ targetSh ++ "\" "
@@ -65,10 +65,10 @@ startChezCmd : String -> String -> String -> String
 startChezCmd chez appDirSh targetSh = unlines
     [ "@echo off"
     , "set APPDIR=%~dp0"
-    , "set PATH=%APPDIR%\\" ++ appDirSh ++ ";%PATH%"
+    , "set PATH=%APPDIR%" ++ appDirSh ++ ";%PATH%"
     , "\"" ++ chez ++ "\" -q "
-        ++ "--libdirs \"%APPDIR%/" ++ appDirSh ++ "\" "
-        ++ "--program \"%APPDIR%/" ++ targetSh ++ "\" "
+        ++ "--libdirs \"%APPDIR%" ++ appDirSh ++ "\" "
+        ++ "--program \"%APPDIR%" ++ targetSh ++ "\" "
         ++ "%*"
     ]
 
@@ -78,11 +78,10 @@ startChezWinSh chez appDirSh targetSh = unlines
     , ""
     , "set -e # exit on any error"
     , ""
-    , "DIR=$(dirname \"$(readlink -f -- \"$0\")\")"
-    , "CHEZ=$(cygpath \"" ++ chez ++"\")"
-    , "export PATH=\"$DIR/" ++ appDirSh ++ "\":$PATH"
-    , "\"$CHEZ\" --program \"$DIR/" ++ targetSh ++ "\" \"$@\""
-    , "\"$CHEZ\" -q "
+    , "DIR=$(dirname \"$(readlink -f -- \"$0\" || cygpath -a -- \"$0\")\")"
+    , "PATH=\"$DIR/" ++ appDirSh ++ ":$PATH\""
+    , "\"" ++ chez ++ "\" --program \"$DIR/" ++ targetSh ++ "\" \"$@\""
+    , "\"" ++ chez ++ "\" -q "
         ++ "--libdirs \"$DIR/" ++ appDirSh ++ "\" "
         ++ "--program \"$DIR/" ++ targetSh ++ "\" "
         ++ "\"$@\""

--- a/src/Compiler/Scheme/Racket.idr
+++ b/src/Compiler/Scheme/Racket.idr
@@ -340,7 +340,7 @@ startRacket racket appdir target = unlines
     , "  DIR=$(dirname \"$(readlink -f -- \"$0\")\")"
     , "fi"
     , ""
-    , "export LD_LIBRARY_PATH=\"$DIR/" ++ appdir ++ "\":$LD_LIBRARY_PATH"
+    , "export LD_LIBRARY_PATH=\"$DIR/" ++ appdir ++ ":$LD_LIBRARY_PATH\""
     , racket ++ "\"$DIR/" ++ target ++ "\" \"$@\""
     ]
 
@@ -348,8 +348,8 @@ startRacketCmd : String -> String -> String -> String
 startRacketCmd racket appdir target = unlines
     [ "@echo off"
     , "set APPDIR=%~dp0"
-    , "set PATH=%APPDIR%\\" ++ appdir ++ ";%PATH%"
-    , racket ++ "\"%APPDIR%\\" ++ target ++ "\" %*"
+    , "set PATH=%APPDIR%" ++ appdir ++ ";%PATH%"
+    , racket ++ "\"%APPDIR%" ++ target ++ "\" %*"
     ]
 
 startRacketWinSh : String -> String -> String -> String
@@ -358,8 +358,8 @@ startRacketWinSh racket appdir target = unlines
     , ""
     , "set -e # exit on any error"
     , ""
-    , "DIR=$(dirname \"$(readlink -f -- \"$0\")\")"
-    , "export PATH=\"$DIR/" ++ appdir ++ "\":$PATH"
+    , "DIR=$(dirname \"$(readlink -f -- \"$0\" || cygpath -a -- \"$0\")\")"
+    , "PATH=\"$DIR/" ++ appdir ++ ":$PATH\""
     , racket ++ "\"$DIR/" ++ target ++ "\" \"$@\""
     ]
 


### PR DESCRIPTION
@TDecki
I've put `readlink -f -- "$0" || cygpath -a -- "$0"` because readlink/realpath failed across VirtualBox shared folders (i.e. network path).

`%APPDIR%` already has a trailing backslash. The rest is straightforward enough.